### PR TITLE
Fix(frontend): Load openwam.js as a module

### DIFF
--- a/frontend/src/services/wasmService.js
+++ b/frontend/src/services/wasmService.js
@@ -22,6 +22,7 @@ export const initWasm = () => {
     // Create a script element to load the Emscripten-generated glue code.
     const script = document.createElement('script');
     script.src = '/openwam.js'; // The script is in the public folder
+    script.type = 'module';
     script.async = true;
     document.body.appendChild(script);
 


### PR DESCRIPTION
The `openwam.js` script, which is the Emscripten-generated glue code for the WebAssembly module, uses ES module features like `import.meta`.

The script was being loaded dynamically without `type='module'`, causing a runtime error: "Cannot use 'import.meta' outside a module".

This change adds `script.type = 'module'` to the dynamically created script tag in `frontend/src/services/wasmService.js` to ensure the browser treats it as a module, resolving the error.