### PR TITLE
Fixes the 'Failed to load the simulation engine' error by correcting …

### DIFF
--- a/frontend/final_build.log
+++ b/frontend/final_build.log
@@ -1,0 +1,25 @@
+
+> frontend@0.1.0 build
+> react-scripts build
+
+Creating an optimized production build...
+Compiled successfully.
+
+File sizes after gzip:
+
+  127.33 kB  build/static/js/main.9b49fd41.js
+  1.76 kB    build/static/js/453.670e15c7.chunk.js
+  495 B      build/static/css/main.13de7379.css
+
+The project was built assuming it is hosted at /.
+You can control this with the homepage field in your package.json.
+
+The build folder is ready to be deployed.
+You may serve it with a static server:
+
+  npm install -g serve
+  serve -s build
+
+Find out more about deployment here:
+
+  https://cra.link/deployment

--- a/frontend/frontend.log
+++ b/frontend/frontend.log
@@ -1,8 +1,0 @@
-npm error code ENOENT
-npm error syscall open
-npm error path /app/frontend/frontend/package.json
-npm error errno -2
-npm error enoent Could not read package.json: Error: ENOENT: no such file or directory, open '/app/frontend/frontend/package.json'
-npm error enoent This is related to npm not being able to find a file.
-npm error enoent
-npm error A complete log of this run can be found in: /home/jules/.npm/_logs/2025-09-24T04_37_34_162Z-debug-0.log

--- a/frontend/src/services/wasmService.js
+++ b/frontend/src/services/wasmService.js
@@ -1,5 +1,3 @@
-/* global Module */
-
 // This service wraps the WebAssembly module and provides a simple interface to it.
 
 let wasmModule;
@@ -19,7 +17,7 @@ export const initWasm = async () => {
   try {
     // Dynamically import the Emscripten-generated glue code.
     // The '.default' is needed because it's a default export.
-    const openWamModuleFactory = (await import('/openwam.js')).default;
+    const openWamModuleFactory = (await import(window.location.origin + '/openwam.js')).default;
     console.log('WASM module factory loaded.');
 
     const moduleArgs = {


### PR DESCRIPTION
…how the WebAssembly module is imported.

The original code used `import('/openwam.js')`. This was causing a Webpack 'Module not found' error because Create React App does not support direct imports from outside the `src` directory.

The fix changes the import to use a full, dynamic URL: `import(window.location.origin + '/openwam.js')`. This prevents Webpack from trying to bundle the file and correctly loads it at runtime from the `public` folder where it is served.

This also resolves the ESLint warning for the unused 'Module' global.

Note: `npm audit` reports several vulnerabilities in the development dependencies. These were not addressed as they are deep in the `react-scripts` dependency tree and attempting to fix them with `--force` would introduce breaking changes, which is outside the scope of this bug fix.